### PR TITLE
Correctly import mods and items on offline import

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1114,27 +1114,6 @@ function ItemsTabClass:DeleteItem(item, deferUndoState)
 			break
 		end
 	end
-	for _, spec in pairs(self.build.treeTab.specList) do
-		local rebuildClusterJewelGraphs = false
-		for nodeId, itemId in pairs(spec.jewels) do
-			if itemId == item.id then
-				spec.jewels[nodeId] = 0
-				rebuildClusterJewelGraphs = true
-				-- Deallocate all nodes that required this jewel
-				if spec.nodes[nodeId] then
-					for depNodeId, depNode in ipairs(spec.nodes[nodeId].depends) do
-						depNode.alloc = 0
-						spec.allocNodes[depNodeId] = nil
-					end
-					spec.nodes[nodeId].alloc = 0
-					spec.allocNodes[nodeId] = nil
-				end
-			end
-		end
-		if rebuildClusterJewelGraphs and not deferUndoState then
-			spec:BuildClusterJewelGraphs()
-		end
-	end
 	self.items[item.id] = nil
 	if not deferUndoState then
 		self:PopulateSlots()


### PR DESCRIPTION
Fixes #9

### Description of the problem being solved:
Fix the import algorithm (fix the unique ID, fix rolls for unique mods and support sealed affixes) + Fix a crash when importing items