### PR TITLE
Fix crash when selecting skills with triggered ailments in the web version

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -862,7 +862,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				if not group then
 					-- Create a new group for this skill
 					group = { label = "", enabled = true, source = grantedSkill.source, slot = grantedSkill.slotName }
-					t_insert(build.skillsTab.socketGroupList, 5 + grantedIndex, group)
+					build.skillsTab.socketGroupList[5 + grantedIndex] = group
 					markList[group] = true
 				end
 


### PR DESCRIPTION
### Description of the problem being solved:
This fixes the error `In 'OnFrame': Modules/CalcSetup.lua:865: bad argument #2 to 't_insert'` which appears on the web version. This error does not appear in the desktop version due to the difference in lua version (5.1 vs 5.2).

The error appeared when selecting a skill that triggered an ailment like "Aura of decay" or "Serpent strike". Only if there was less than 5 skills selected