### PR TITLE
Support for idol altar items and for bigger affix ids on offline import

### DIFF
--- a/spec/System/TestItemImport_spec.lua
+++ b/spec/System/TestItemImport_spec.lua
@@ -123,4 +123,85 @@ describe("Offline Item Import", function()
         }
         assert.are.same(expected, item)
     end)
+
+    it("should process idol altar slot correctly", function()
+        local itemDataJson = [[
+        {
+        "itemData": null,
+        "data": [
+            5,
+            70,
+            46,
+            41,
+            5,
+            2,
+            16,
+            60,
+            44,
+            63,
+            0,
+            67,
+            36,
+            81,
+            10,
+            36,
+            73,
+            191,
+            4,
+            70,
+            51,
+            0
+        ],
+        "inventoryPosition": {
+            "x": 0,
+            "y": 0
+        },
+        "quantity": 1,
+        "containerID": 123,
+        "formatVersion": 2
+        }
+        ]]
+        local item = build.importTab:processItemData(processJson(itemDataJson))
+
+        local expected = {
+          ["base"] = {
+            ["affixEffectModifier"] = 0,
+            ["baseTypeID"] = 41,
+            ["implicits"] = {
+              [1] = '{rounding:Integer}+(6-10) Health per Equipped Omen Idol'
+            },
+            ["req"] = {
+              ["level"] = 0
+            },
+            ["subTypeID"] = 5,
+            ["type"] = 'Idol Altar'
+          },
+          ["baseName"] = 'Visage Altar',
+          ["explicitMods"] = { },
+          ["implicitMods"] = {
+            [1] = '{range: 60}{rounding:Integer}+(6-10) Health per Equipped Omen Idol'
+          },
+          ["name"] = 'Visage Altar',
+          ["prefixes"] = {
+            [1] = {
+              ["modId"] = '1097_2',
+              ["range"] = 191
+            }
+          },
+          ["rarity"] = 'RARE',
+          ["rarityType"] = 'BASIC',
+          ["slotName"] = 'Idol Altar',
+          ["suffixes"] = {
+            [1] = {
+              ["modId"] = '1105_2',
+              ["range"] = 10
+            },
+            [2] = {
+              ["modId"] = '1094_0',
+              ["range"] = 51
+            }
+          }
+        }
+        assert.are.same(expected, item)
+    end)
 end)

--- a/spec/TestBuilds/1.2/minions.xml
+++ b/spec/TestBuilds/1.2/minions.xml
@@ -880,6 +880,7 @@ Implicits: 1
 			<Slot itemId="12" itemPbURL="" name="Idol 7"></Slot>
 			<Slot itemId="0" itemPbURL="" name="Idol 8"></Slot>
 			<Slot itemId="0" itemPbURL="" name="Idol 9"></Slot>
+			<Slot itemId="0" itemPbURL="" name="Idol Altar"></Slot>
 			<Slot itemId="6" itemPbURL="" name="Relic"></Slot>
 			<Slot itemId="7" itemPbURL="" name="Ring 1"></Slot>
 			<Slot itemId="8" itemPbURL="" name="Ring 2"></Slot>

--- a/spec/TestBuilds/1.2/tornado_dot.xml
+++ b/spec/TestBuilds/1.2/tornado_dot.xml
@@ -885,6 +885,7 @@ Implicits: 1
 			<Slot itemId="12" itemPbURL="" name="Idol 7"></Slot>
 			<Slot itemId="13" itemPbURL="" name="Idol 8"></Slot>
 			<Slot itemId="14" itemPbURL="" name="Idol 9"></Slot>
+			<Slot itemId="0" itemPbURL="" name="Idol Altar"></Slot>
 			<Slot itemId="6" itemPbURL="" name="Relic"></Slot>
 			<Slot itemId="7" itemPbURL="" name="Ring 1"></Slot>
 			<Slot itemId="8" itemPbURL="" name="Ring 2"></Slot>

--- a/spec/TestBuilds/1.2/warpath_channel.xml
+++ b/spec/TestBuilds/1.2/warpath_channel.xml
@@ -782,6 +782,7 @@ Implicits: 1
 			<Slot itemId="16" itemPbURL="" name="Idol 7"></Slot>
 			<Slot itemId="0" itemPbURL="" name="Idol 8"></Slot>
 			<Slot itemId="0" itemPbURL="" name="Idol 9"></Slot>
+			<Slot itemId="0" itemPbURL="" name="Idol Altar"></Slot>
 			<Slot itemId="6" itemPbURL="" name="Relic"></Slot>
 			<Slot itemId="7" itemPbURL="" name="Ring 1"></Slot>
 			<Slot itemId="8" itemPbURL="" name="Ring 2"></Slot>

--- a/spec/TestBuilds/1.3/offline_save.xml
+++ b/spec/TestBuilds/1.3/offline_save.xml
@@ -665,6 +665,7 @@ Implicits: 0
 			<Slot itemId="0" itemPbURL="" name="Idol 7"></Slot>
 			<Slot itemId="20" itemPbURL="" name="Idol 8"></Slot>
 			<Slot itemId="12" itemPbURL="" name="Idol 9"></Slot>
+			<Slot itemId="0" itemPbURL="" name="Idol Altar"></Slot>
 			<Slot itemId="11" itemPbURL="" name="Relic"></Slot>
 			<Slot itemId="9" itemPbURL="" name="Ring 1"></Slot>
 			<Slot itemId="8" itemPbURL="" name="Ring 2"></Slot>

--- a/spec/TestBuilds/1.3/throwing.xml
+++ b/spec/TestBuilds/1.3/throwing.xml
@@ -732,6 +732,7 @@ Implicits: 1
 			<Slot itemId="16" itemPbURL="" name="Idol 7"></Slot>
 			<Slot itemId="0" itemPbURL="" name="Idol 8"></Slot>
 			<Slot itemId="0" itemPbURL="" name="Idol 9"></Slot>
+			<Slot itemId="0" itemPbURL="" name="Idol Altar"></Slot>
 			<Slot itemId="6" itemPbURL="" name="Relic"></Slot>
 			<Slot itemId="7" itemPbURL="" name="Ring 1"></Slot>
 			<Slot itemId="8" itemPbURL="" name="Ring 2"></Slot>

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -663,7 +663,7 @@ function ImportTabClass:DownloadPassiveTree()
     self:ImportPassiveTreeAndJewels(charData)
 end
 
-local offlineImportSlotMap = { [4] = "Weapon 1", [5] = "Weapon 2", [2] = "Helmet", [3] = "Body Armor", [6] = "Gloves", [8] = "Boots", [11] = "Amulet", [9] = "Ring 1", [10] = "Ring 2", [7] = "Belt", [12] = "Relic" }
+local offlineImportSlotMap = { [4] = "Weapon 1", [5] = "Weapon 2", [2] = "Helmet", [3] = "Body Armor", [6] = "Gloves", [8] = "Boots", [11] = "Amulet", [9] = "Ring 1", [10] = "Ring 2", [7] = "Belt", [12] = "Relic", [123] = "Idol Altar" }
 
 for i = 1, 7 do
     offlineImportSlotMap[32 + i] = "Blessing " .. i
@@ -675,7 +675,8 @@ end
 function ImportTabClass:processItemData(itemData)
     if itemData["containerID"] <= 12 or itemData["containerID"] == 29 or
             itemData["containerID"] >= 33 and itemData["containerID"] <= 39 or
-            itemData["containerID"] >= 43 and itemData["containerID"] <= 45 then
+            itemData["containerID"] >= 43 and itemData["containerID"] <= 45 or
+            itemData["containerID"] == 123 then
         local item = {
         }
         local baseTypeID = itemData["data"][4]
@@ -738,7 +739,7 @@ function ImportTabClass:processItemData(itemData)
                             -- There are cases where the "nbAffixesIndex" value is wrong, not sure why but
                             -- we should at least prevent a crash when it's higher than expected (could it be lower?)
                             if itemData["data"][dataId] then
-                                local affixId = itemData["data"][dataId + 1] + (itemData["data"][dataId] % 4) * 256
+                                local affixId = itemData["data"][dataId + 1] + (itemData["data"][dataId] % 16) * 256
                                 local affixTier = math.floor(itemData["data"][dataId] / 16)
                                 local modId = affixId .. "_" .. affixTier
                                 local modData = data.itemMods.Item[modId]
@@ -760,7 +761,7 @@ function ImportTabClass:processItemData(itemData)
                     for i = 0, 4 do
                         local dataId = 14 + i * 3
                         if #itemData["data"] > dataId then
-                            local affixId = itemData["data"][dataId] + (itemData["data"][dataId - 1] % 4) * 256
+                            local affixId = itemData["data"][dataId] + (itemData["data"][dataId - 1] % 16) * 256
                             if affixId then
                                 local affixTier = math.floor(itemData["data"][dataId - 1] / 16)
                                 local modId = affixId .. "_" .. affixTier

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -22,7 +22,7 @@ local rarityDropList = {
 	{ label = colorCodes.IDOL.."Idol", rarity = "IDOL" },
 }
 
-local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armor", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Belt", "Relic" }
+local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armor", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Belt", "Relic", "Idol Altar" }
 
 for i = 1, 20 do
 	table.insert(baseSlots, "Idol " .. i)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -665,7 +665,8 @@ function buildMode:ReadLeToolsSave(saveContent)
 		["ring1"] = "Ring 1",
 		["ring2"] = "Ring 2",
 		["waist"] = "Belt",
-		["relic"] = "Relic"
+		["relic"] = "Relic",
+		["idol_altar"] = "Idol Altar",
 	}
 
 	for i = 1, 10 do


### PR DESCRIPTION
### Description of the problem being solved:
Support for idol altar slots. It also fixes wrong affix ids on offline import when the affix id was too big