### PR TITLE
Better support for importing a build code for an older version of the game

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -658,6 +658,9 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				self.visibleNodes[nodeId] = node
 			end
 		end
+		if node.alloc > 0 then
+			self.visibleNodes[nodeId] = node
+		end
 	end
 	-- Check all nodes for other nodes which depend on them (i.e. are only connected to the tree through that node)
 	for id, node in pairs(self.visibleNodes) do

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -221,11 +221,13 @@ function SkillsTabClass:LoadSkill(node, skillSetId)
 	local grantedEffect = self.build.data.skills[skillId]
 	socketGroup.skillId = skillId
 	socketGroup.grantedEffect = grantedEffect
-	self:ProcessSocketGroup(socketGroup)
-	if node.attrib.index then
-	    self.skillSets[skillSetId].socketGroupList[tonumber(node.attrib.index)] = socketGroup
-	else
-		t_insert(self.skillSets[skillSetId].socketGroupList, socketGroup)
+	if grantedEffect then
+		self:ProcessSocketGroup(socketGroup)
+		if node.attrib.index then
+		    self.skillSets[skillSetId].socketGroupList[tonumber(node.attrib.index)] = socketGroup
+		else
+			t_insert(self.skillSets[skillSetId].socketGroupList, socketGroup)
+		end
 	end
 end
 

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -63,7 +63,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	end
 	if self.targetVersion ~= liveTargetVersion then
 		self.targetVersion = nil
-		self:OpenConversionPopup()
+		self:OpenConversionPopup(buildXML)
 		return
 	end
 
@@ -1084,7 +1084,7 @@ function buildMode:OnFrame(inputEvents)
 end
 
 -- Opens the game version conversion popup
-function buildMode:OpenConversionPopup()
+function buildMode:OpenConversionPopup(buildXML)
 	local controls = { }
 	local currentVersion = treeVersions[latestTreeVersion].display
 	controls.note = new("LabelControl", nil, 0, 20, 0, 16, colorCodes.TIP..[[
@@ -1102,7 +1102,7 @@ You should create a backup copy of the build before proceeding.
 	controls.convert = new("ButtonControl", nil, -40, 170, 120, 20, "Convert to ".. currentVersion, function()
 		main:ClosePopup()
 		self:Shutdown()
-		self:Init(self.dbFileName, self.buildName, nil, true)
+		self:Init(self.dbFileName, self.buildName, buildXML, true)
 	end)
 	controls.cancel = new("ButtonControl", nil, 60, 170, 70, 20, "Cancel", function()
 		main:ClosePopup()


### PR DESCRIPTION
### Description of the problem being solved:
Currently, when we try to use a build code generated from an older version of the tool (and game), this does nothing (it just loads an empty build). I fixed it, along with some possible crashes due to possible incompatibilities