### PR TITLE
Use letools api for importing its planner url

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -257,7 +257,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
             for line in buf:gmatch("([^\n]+)") do
                 if line:find("fromSaveFile") then
                     -- Change the buffer here to avoid matching url from other parts of the buffer
-                    buf = line:match("%w* = (%b{})")
+                    buf = line:match("%w* = (%b{})") or line
                     xmlText = buf
                 end
             end

--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -9,7 +9,7 @@ buildSites = { }
 -- Import/Export websites list used in dropdowns
 buildSites.websiteList = {
 	{
-		label = "lastepochtools.com", id = "lastepochtools", matchURL = "lastepochtools.com/planner/.+", regexURL = "lastepochtools.com/planner/(.+)$", downloadURL = "lastepochtools.com/planner/%1"
+		label = "lastepochtools.com", id = "lastepochtools", matchURL = "lastepochtools.com/planner/.+", regexURL = "lastepochtools.com/planner/(.+)$", downloadURL = "lastepochtools.com/api/public/build_data/%1"
 	},
 	{
 		label = "Pastebin.com", id = "pastebin", matchURL = "pastebin%.com/%w+", regexURL = "pastebin%.com/(%w+)%s*$", downloadURL = "pastebin.com/raw/%1",


### PR DESCRIPTION
### Description of the problem being solved:
Use the new letools api to import builds from urls like "https://www.lastepochtools.com/planner/xxxxxx"

A second PR will take care of the import of online character when the API allows it